### PR TITLE
Add `milestone_id` to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Default: false
 
 
 ## Outputs
-None
+### `milestone_id`
+The id of the milestone which has been closed.
 
 ## Explanation for usage
 - The `uses` keyword specifies which action us used. `Akkjon/close-milestone` specifies which repository is used, the `@v2.0.2` defines which version of the action is used. To always use the latest version, you can change it to `@master`, but please be aware that changes in the action might break your workflow.

--- a/action.yml
+++ b/action.yml
@@ -6,11 +6,14 @@ branding:
   color: blue
 inputs:
   milestone_name:
-    description: 'The name of the minlestone.'
+    description: 'The name of the milestone.'
     required: true
   crash_on_missing:
-    description: 'If the Milestone should crash with an exit code if the provided Milestone is not found.'
+    description: 'If the action should crash with an exit code if the provided milestone is not found.'
     default: false
+outputs:
+  milestone_id:
+    description: 'The id of the milestone which has been closed.'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -124,7 +124,8 @@ async function run() {
         }
         return;
     }
-    await closeMilestone(id)
+    await closeMilestone(id);
+    core.setOutput('milestone_id', id);
 }
 
 //starts the workflow


### PR DESCRIPTION
This registers the output `milestone_id` when successfully closing a milestone. This allows to chain to other actions requiring the id.

Example :

```yml
name: close-milestone
run-name: Close milestone ${{ github.ref_name }}

on:
  release:
    types: [published]

jobs:
  close:
    #if: github.repository == 'mistic100/Photo-Sphere-Viewer'

    runs-on: ubuntu-latest

    steps:
      - id: close
        uses: mistic100/close-milestone@main
        with:
          milestone_name: ${{ github.ref_name }}
          crash_on_missing: false
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

      - if: ${{ steps.close.outputs.milestone_id != null }}
        uses: bflad/action-milestone-comment@v1
        with:
          milestone: ${{ steps.close.outputs.milestone_id }}
          body: |
            This feature/bug fix has been released in [version ${{ github.ref_name }}](https://github.com/mistic100/Photo-Sphere-Viewer/releases/tag/${{ github.ref_name }}).
```

-----

**Note** You are using an old version of `@actions/core` which issues a deprecation warning

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I have updated all the dependencies on my fork ([relevant commit](https://github.com/mistic100/close-milestone/commit/08c3e798018f17648b5870eff1f0a12a7ef991d3)) but didn't want to bloat this PR with all the node_modules diff. So I could create another PR once this one is accepted.